### PR TITLE
Pluggable providers

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -24,7 +24,7 @@ const (
 )
 
 //keys returns a slice of keys from any authorised accounts
-func (a AwsKey) keys(project string, includeInactiveKeys bool) (keys []Key, err error) {
+func (a AwsKey) Keys(project string, includeInactiveKeys bool) (keys []Key, err error) {
 	var svc *awsiam.IAM
 	if svc, err = iamService(); err != nil {
 		return
@@ -59,7 +59,7 @@ func (a AwsKey) keys(project string, includeInactiveKeys bool) (keys []Key, err 
 }
 
 //createKey creates a key in the provided account
-func (a AwsKey) createKey(project, account string) (keyID, newKey string, err error) {
+func (a AwsKey) CreateKey(project, account string) (keyID, newKey string, err error) {
 	var svc *awsiam.IAM
 	if svc, err = iamService(); err != nil {
 		return
@@ -87,7 +87,7 @@ func (a AwsKey) createKey(project, account string) (keyID, newKey string, err er
 }
 
 //deleteKey deletes the specified key from the specified account
-func (a AwsKey) deleteKey(project, account, keyID string) (err error) {
+func (a AwsKey) DeleteKey(project, account, keyID string) (err error) {
 	var svc *awsiam.IAM
 	if svc, err = iamService(); err != nil {
 		return

--- a/gcp.go
+++ b/gcp.go
@@ -17,7 +17,7 @@ import (
 type GcpKey struct{}
 
 //keys returns a slice of keys from any authorised accounts
-func (g GcpKey) keys(project string, includeInactiveKeys bool) (keys []Key, err error) {
+func (g GcpKey) Keys(project string, includeInactiveKeys bool) (keys []Key, err error) {
 	if err = validateGcpProjectString(project); err != nil {
 		return
 	}
@@ -83,7 +83,7 @@ func keyFromGcpKey(gcpKey *gcpiam.ServiceAccountKey, project string) (key Key, e
 }
 
 //createKey creates a key in the provided account
-func (g GcpKey) createKey(project, account string) (keyID, newKey string, err error) {
+func (g GcpKey) CreateKey(project, account string) (keyID, newKey string, err error) {
 	if err = validateGcpProjectString(project); err != nil {
 		return
 	}
@@ -105,7 +105,7 @@ func (g GcpKey) createKey(project, account string) (keyID, newKey string, err er
 }
 
 //deleteKey deletes the specified key from the specified account
-func (g GcpKey) deleteKey(project, account, keyID string) (err error) {
+func (g GcpKey) DeleteKey(project, account, keyID string) (err error) {
 	if err = validateGcpProjectString(project); err != nil {
 		return
 	}

--- a/keys.go
+++ b/keys.go
@@ -49,7 +49,7 @@ var providerMap = map[string]ProviderInterface{gcpProviderString: GcpKey{},
 var logger = stdoutLogger().Sugar()
 
 //RegisterProvider informs the tool about a new cloud provider, in addition to AWS and GCP, and registers it under a unique key
-func RegisterProvider(providerName string, provider interface{}) {
+func RegisterProvider(providerName string, provider ProviderInterface) {
 	providerMap[providerName] = provider
 }
 

--- a/keys.go
+++ b/keys.go
@@ -9,9 +9,9 @@ import (
 
 //ProviderInterface type
 type ProviderInterface interface {
-	keys(project string, includeInactiveKeys bool) (keys []Key, err error)
-	createKey(project, account string) (keyID, newKey string, err error)
-	deleteKey(project, account, keyID string) (err error)
+	Keys(project string, includeInactiveKeys bool) (keys []Key, err error)
+	CreateKey(project, account string) (keyID, newKey string, err error)
+	DeleteKey(project, account, keyID string) (err error)
 }
 
 //Key type
@@ -58,7 +58,7 @@ func Keys(providers []Provider, includeInactiveKeys bool) (keys []Key, err error
 	for _, providerRequest := range providers {
 		var providerKeys []Key
 		if providerKeys, err = providerMap[providerRequest.Provider].
-			keys(providerRequest.GcpProject, includeInactiveKeys); err != nil {
+			Keys(providerRequest.GcpProject, includeInactiveKeys); err != nil {
 			return
 		}
 		keys = appendSlice(keys, providerKeys)
@@ -69,7 +69,7 @@ func Keys(providers []Provider, includeInactiveKeys bool) (keys []Key, err error
 //CreateKeyFromScratch creates a new key from just provider and account
 //parameters (an existing key is not required)
 func CreateKeyFromScratch(provider Provider, account string) (string, string, error) {
-	return providerMap[provider.Provider].createKey(provider.GcpProject, account)
+	return providerMap[provider.Provider].CreateKey(provider.GcpProject, account)
 }
 
 //CreateKey creates a new key using details of the provided key
@@ -79,7 +79,7 @@ func CreateKey(key Key) (string, string, error) {
 
 //DeleteKey deletes the specified key
 func DeleteKey(key Key) error {
-	return providerMap[key.Provider.Provider].deleteKey(key.Provider.GcpProject, key.FullAccount, key.ID)
+	return providerMap[key.Provider.Provider].DeleteKey(key.Provider.GcpProject, key.FullAccount, key.ID)
 }
 
 //appendSlice appends the 2nd slice to the 1st, and returns the resulting slice

--- a/keys.go
+++ b/keys.go
@@ -48,6 +48,11 @@ var providerMap = map[string]ProviderInterface{gcpProviderString: GcpKey{},
 
 var logger = stdoutLogger().Sugar()
 
+//RegisterProvider informs the tool about a new cloud provider, in addition to AWS and GCP, and registers it under a unique key
+func RegisterProvider(providerName string, provider interface{}) {
+	providerMap[providerName] = provider
+}
+
 //Keys returns a generic key slice of potentially multiple provider keys
 func Keys(providers []Provider, includeInactiveKeys bool) (keys []Key, err error) {
 	for _, providerRequest := range providers {


### PR DESCRIPTION
This change makes it so new cloud providers can be added, without needing to open up the cloud-key-client package.

This relates to adding an end-to-end test to cloud-key-rotator, with a local / mocked provider.  This is arguably an anti-pattern, as this article suggests we should mock the public API instead.  I think this is more of a grey area, as we do already have a couple of cloud provider implementations and I don't think this could be called an early optimisation.  I may be wrong though.  See https://github.com/golang/go/wiki/CodeReviewComments#interfaces.